### PR TITLE
fix: avoid crashing if logo passed multiple times

### DIFF
--- a/server/controllers/controller.ts
+++ b/server/controllers/controller.ts
@@ -9,7 +9,8 @@ async function listIconsJSON(req: Request, res: Response): Promise<void> {
 }
 
 async function getBadge(req: Request, res: Response): Promise<void> {
-  const slug = (req.query.logo || '') as string;
+  // get logo from query, use first if multiple
+  const slug = `${req.query.logo}`.split(',').shift() || '';
   // check if slug exists
   const item = slug ? await iconDatabase.checkSlugExists(slug) : null;
   // get badge for item

--- a/server/controllers/controller.ts
+++ b/server/controllers/controller.ts
@@ -9,7 +9,7 @@ async function listIconsJSON(req: Request, res: Response): Promise<void> {
 }
 
 async function getBadge(req: Request, res: Response): Promise<void> {
-  // get logo from query, use first if multiple
+  // get logo from query as a string, use first if multiple
   const slug = `${req.query.logo}`.split(',').shift() || '';
   // check if slug exists
   const item = slug ? await iconDatabase.checkSlugExists(slug) : null;

--- a/server/services/fetchBadges.ts
+++ b/server/services/fetchBadges.ts
@@ -42,7 +42,7 @@ function buildQueryStringFromItem(
   let { data } = item;
   // check for logoColor parameter if it is SVG
   if (req.query.logoColor && item.type === 'svg+xml') {
-    // get the logo color as a string
+    // get the logo color as a string, use first if multiple
     const color = `${req.query.logoColor}`.split(',').shift() || '';
     data = setLogoColor(data, color);
   }

--- a/server/services/fetchBadges.ts
+++ b/server/services/fetchBadges.ts
@@ -42,8 +42,8 @@ function buildQueryStringFromItem(
   let { data } = item;
   // check for logoColor parameter if it is SVG
   if (req.query.logoColor && item.type === 'svg+xml') {
-    // set logo color
-    const color = req.query.logoColor as string;
+    // get the logo color as a string
+    const color = `${req.query.logoColor}`.split(',').shift() || '';
     data = setLogoColor(data, color);
   }
   // replace logo with data url in query


### PR DESCRIPTION
Fixes a case where the app crashes if `logo` or `logoColor` is specified in the url multiple times.

Eg. `?logo=file-diff&logo`

This change makes it so only the first logo is used and does not allow slug to be an array.

```ts
/custom-icon-badges/dist/services/iconDatabase.js:49
            return [2 /*return*/, icons.findOne({ slug: slug.toLowerCase() })];
                                                             ^

TypeError: slug.toLowerCase is not a function
```