### PR TITLE
fix: allow hsl, rgb formats, consistency with shields.io

### DIFF
--- a/server/controllers/controller.ts
+++ b/server/controllers/controller.ts
@@ -9,8 +9,8 @@ async function listIconsJSON(req: Request, res: Response): Promise<void> {
 }
 
 async function getBadge(req: Request, res: Response): Promise<void> {
-  // get logo from query as a string, use first if multiple
-  const slug = `${req.query.logo}`.split(',').shift() || '';
+  // get logo from query as a string, use nothing if multiple or empty
+  const slug = typeof req.query.logo === 'string' ? req.query.logo : '';
   // check if slug exists
   const item = slug ? await iconDatabase.checkSlugExists(slug) : null;
   // get badge for item

--- a/server/services/fetchBadges.ts
+++ b/server/services/fetchBadges.ts
@@ -41,9 +41,8 @@ function buildQueryStringFromItem(
   }
   let { data } = item;
   // check for logoColor parameter if it is SVG
-  if (req.query.logoColor && item.type === 'svg+xml') {
-    // get the logo color as a string, use first if multiple
-    const color = `${req.query.logoColor}`.split(',').shift() || '';
+  if (typeof req.query.logoColor === 'string' && item.type === 'svg+xml') {
+    const color = req.query.logoColor;
     data = setLogoColor(data, color);
   }
   // replace logo with data url in query


### PR DESCRIPTION
Fixes logoColor to accept hsl(0,0,0) and rgb(0,0,0) formats. #422 broke this since it was assuming no commas.

Breaking change: if the logo or logoColor is specified multiple times in the URL, instead of using the first occurrence, the logo or logoColor will be considered **empty** respectively. This is a change to what was first made working when #422 was merged (~1 hr ago). This makes the behavior consistent with https://shields.io/.