### PR TITLE
feat!: default Octicons to whitesmoke fill color

### DIFF
--- a/server/services/octicons.ts
+++ b/server/services/octicons.ts
@@ -12,8 +12,8 @@ async function getIcon(slug: string):
     return null;
   }
   const icon = octicons[normalized as IconName];
-  // add 'xmlns' attribute to the svg
-  const svg = icon.toSVG().replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
+  // add 'xmlns' and 'fill' attribute to the svg
+  const svg = icon.toSVG().replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg" fill="whitesmoke"');
   return {
     slug: icon.symbol,
     type: 'svg+xml',


### PR DESCRIPTION
## Description

For consistency with Simple Icons on shields.io, this makes Octicons have `whitesmoke` as the default fill color unless overridden by the `logoColor` parameter.

Logos that were previously black by default will now be whitesmoke color.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [x] Tested endpoints locally

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/custom-icon-badges/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
