### PR TITLE
feat: Allow changing host when fetching badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,6 @@ Demo site: <https://custom-icon-badges.herokuapp.com>
 
 [![image](https://user-images.githubusercontent.com/20955511/128404656-30af9c39-39a4-4ac8-a4b0-2a077806a94c.png)](https://custom-icon-badges.herokuapp.com)
 
-## 🖥️ Using a Different Badge Host
-
-By default, fetching a badge from Custom Icon Badges will use [`img.shields.io`](https://img.shields.io) as the badge host.
-
-If you would like to use a different badge host, you can add the `host` parameter to one of the following:
-
--   [`img.shields.io`](https://img.shields.io)
--   [`staging.shields.io`](https://staging.shields.io)
--   [`formatted-dynamic-badges.herokuapp.com`](https://formatted-dynamic-badges.herokuapp.com)
-
-If you would like to use a different badge host, fork and modify this repository. Create a PR if it may be useful to others.
-
 ## 🚀 Example Usage
 
 Click to get the URL!
@@ -151,6 +139,18 @@ Click to get the URL!
 [24]: https://custom-icon-badges.herokuapp.com/badge/-Use%20GitHub%20Action-blue?style=for-the-badge&logo=workflow&logoColor=white
 [25]: https://custom-icon-badges.herokuapp.com/badge/dynamic/json?logo=fire&logoColor=fff&color=orange&label=github%20streak&query=%24.currentStreak.length&suffix=%20days&url=https%3A%2F%2Fgithub-readme-streak-stats.herokuapp.com%2F%3Fuser%3DDenverCoder1%26type%3Djson
 [26]: https://custom-icon-badges.herokuapp.com/badge/dynamic/json?logo=graph&logoColor=fff&color=blue&label=total%20contributions&query=%24.totalContributions&url=https%3A%2F%2Fgithub-readme-streak-stats.herokuapp.com%2F%3Fuser%3DDenverCoder1%26type%3Djson
+
+## 🖥️ Using a Different Badge Host
+
+By default, fetching a badge from Custom Icon Badges will use [`img.shields.io`](https://img.shields.io) as the badge host.
+
+If you would like to use a different badge host, you can add the `host` parameter to one of the following:
+
+-   [`img.shields.io`](https://img.shields.io)
+-   [`staging.shields.io`](https://staging.shields.io)
+-   [`formatted-dynamic-badges.herokuapp.com`](https://formatted-dynamic-badges.herokuapp.com)
+
+If you would like to use a different badge host, fork and modify this repository. Create a PR if it may be useful to others.
 
 ## 🤗 Contributing
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ Demo site: <https://custom-icon-badges.herokuapp.com>
 
 By default, fetching a badge from Custom Icon Badges will use [`img.shields.io`](https://img.shields.io) as the badge host.
 
-If you would like to use a different badge host, you can add the `host` parameter to the badge URL and set it to one of the following:
+If you would like to use a different badge host, you can add the `host` parameter to one of the following:
 
 -   [`img.shields.io`](https://img.shields.io)
 -   [`staging.shields.io`](https://staging.shields.io)
 -   [`formatted-dynamic-badges.herokuapp.com`](https://formatted-dynamic-badges.herokuapp.com)
 
-If you would like to use a different badge host, fork and modify this repository, and create a PR if it may be useful to others.
+If you would like to use a different badge host, fork and modify this repository. Create a PR if it may be useful to others.
 
 ## 🚀 Example Usage
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Click to get the URL!
 
 By default, fetching a badge from Custom Icon Badges will use [`img.shields.io`](https://img.shields.io) as the badge host.
 
-If you would like to use a different badge host, you can add the `host` parameter to one of the following:
+You can set the `host` parameter to one of the following to override the hostname of the badge URL:
 
 -   [`img.shields.io`](https://img.shields.io)
 -   [`staging.shields.io`](https://staging.shields.io)

--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ You can find a list of slugs for each brand [here](https://github.com/simple-ico
 
 All [Octicons](https://primer.style/octicons/) from GitHub are supported by Custom Icon Badges.
 
-| Slug               | Example                                                                                                |
-| ------------------ | ------------------------------------------------------------------------------------------------------ |
-| `issue-opened`     | ![img](https://custom-icon-badges.herokuapp.com/badge/Issue-red.svg?logo=issue-opened&logoColor=fff)   |
-| `repo-forked`      | ![img](https://custom-icon-badges.herokuapp.com/badge/Fork-orange.svg?logo=fork)                       |
-| `star`             | ![img](https://custom-icon-badges.herokuapp.com/badge/Star-yellow.svg?logo=star)                       |
-| `git-commit`       | ![img](https://custom-icon-badges.herokuapp.com/badge/Commit-green.svg?logo=git-commit&logoColor=fff)  |
-| `repo`             | ![img](https://custom-icon-badges.herokuapp.com/badge/Repo-blue.svg?logo=repo)                         |
-| `git-pull-request` | ![img](https://custom-icon-badges.herokuapp.com/badge/Pull%20Request-purple.svg?logo=pr)               |
-| `heart`            | ![img](https://custom-icon-badges.herokuapp.com/badge/Heart-D15E9B.svg?logo=heart)                     |
-| `mail`             | ![img](https://custom-icon-badges.herokuapp.com/badge/Mail-E61B23.svg?logo=mail)                       |
-| More Octicons      | [View all ⇨](https://primer.style/octicons)                                                            |
+| Slug               | Example                                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| `issue-opened`     | ![img](https://custom-icon-badges.herokuapp.com/badge/Issue-red.svg?logo=issue-opened&logoColor=fff)  |
+| `repo-forked`      | ![img](https://custom-icon-badges.herokuapp.com/badge/Fork-orange.svg?logo=fork)                      |
+| `star`             | ![img](https://custom-icon-badges.herokuapp.com/badge/Star-yellow.svg?logo=star)                      |
+| `git-commit`       | ![img](https://custom-icon-badges.herokuapp.com/badge/Commit-green.svg?logo=git-commit&logoColor=fff) |
+| `repo`             | ![img](https://custom-icon-badges.herokuapp.com/badge/Repo-blue.svg?logo=repo)                        |
+| `git-pull-request` | ![img](https://custom-icon-badges.herokuapp.com/badge/Pull%20Request-purple.svg?logo=pr)              |
+| `heart`            | ![img](https://custom-icon-badges.herokuapp.com/badge/Heart-D15E9B.svg?logo=heart)                    |
+| `mail`             | ![img](https://custom-icon-badges.herokuapp.com/badge/Mail-E61B23.svg?logo=mail)                      |
+| More Octicons      | [View all ⇨](https://primer.style/octicons)                                                           |
 
 ### Miscellaneous
 
@@ -64,7 +64,7 @@ All [Octicons](https://primer.style/octicons/) from GitHub are supported by Cust
 | `trending-down` | ![img](https://custom-icon-badges.herokuapp.com/badge/trending--down-red.svg?logoColor=fff&logo=trending-down)     |
 | `phone`         | ![img](https://custom-icon-badges.herokuapp.com/badge/phone-green.svg?logo=phone&logoColor=white)                  |
 | `swi-prolog`    | ![img](https://custom-icon-badges.herokuapp.com/badge/swi--prolog-E61B23.svg?logo=swi-prolog&logoColor=fff)        |
-| Add your own    | [Upload icon ⇨](https://custom-icon-badges.herokuapp.com)                                                         |
+| Add your own    | [Upload icon ⇨](https://custom-icon-badges.herokuapp.com)                                                          |
 
 ## ➕ Adding a new logo
 
@@ -77,6 +77,18 @@ If you think your icon is useful to others, feel free to open a PR to add it to 
 Demo site: <https://custom-icon-badges.herokuapp.com>
 
 [![image](https://user-images.githubusercontent.com/20955511/128404656-30af9c39-39a4-4ac8-a4b0-2a077806a94c.png)](https://custom-icon-badges.herokuapp.com)
+
+## 🖥️ Using a Different Badge Host
+
+By default, fetching a badge from Custom Icon Badges will use [`img.shields.io`](https://img.shields.io) as the badge host.
+
+If you would like to use a different badge host, you can add the `host` parameter to the badge URL and set it to one of the following:
+
+-   [`img.shields.io`](https://img.shields.io)
+-   [`staging.shields.io`](https://staging.shields.io)
+-   [`formatted-dynamic-badges.herokuapp.com`](https://formatted-dynamic-badges.herokuapp.com)
+
+If you would like to use a different badge host, fork and modify this repository, and create a PR if it may be useful to others.
 
 ## 🚀 Example Usage
 

--- a/server/services/fetchBadges.ts
+++ b/server/services/fetchBadges.ts
@@ -61,7 +61,7 @@ function buildQueryStringFromItem(
   // remove "host" parameter from query string
   delete newQuery.host;
   // build url using request params and query
-  return buildQueryString(rest);
+  return buildQueryString(newQuery);
 }
 
 /**

--- a/server/services/fetchBadges.ts
+++ b/server/services/fetchBadges.ts
@@ -4,6 +4,17 @@ import { ParsedQs } from 'qs';
 import setLogoColor from './setLogoColor';
 
 /**
+ * Error class for exceptions caused during building and fetching of badges
+ */
+class BadgeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BadgeError';
+    Object.setPrototypeOf(this, BadgeError.prototype);
+  }
+}
+
+/**
  * Build query string from ParsedQs
  * @param {ParsedQs} parsedQs query string possibly with replacements
  * @returns {string} query string
@@ -47,8 +58,24 @@ function buildQueryStringFromItem(
   }
   // replace logo with data url in query
   const newQuery = replacedLogoQuery(req, item.type, data);
+  // remove "host" parameter from query string
+  const { host, ...rest } = newQuery;
   // build url using request params and query
-  return buildQueryString(newQuery);
+  return buildQueryString(rest);
+}
+
+/**
+ * Validate hostname is allowed
+ * @param {string|null} host hostname to validate
+ * @returns {boolean} True if host is valid, otherwise false
+ */
+function validHost(host: string): boolean {
+  const validHosts = [
+    'img.shields.io',
+    'staging.shields.io',
+    'formatted-dynamic-badges.herokuapp.com',
+  ];
+  return validHosts.includes(host);
 }
 
 /**
@@ -63,7 +90,11 @@ function getBadgeUrl(
   // build url using request params and query
   const params = Object.values(req.params).map((p) => encodeURIComponent(p)).join('/');
   const queryString = buildQueryStringFromItem(req, item);
-  return `https://img.shields.io/${params}?${queryString}`;
+  const host = typeof req.query.host === 'string' ? req.query.host : 'img.shields.io';
+  if (!validHost(host)) {
+    throw new BadgeError('invalid host');
+  }
+  return `https://${host}/${params}?${queryString}`;
 }
 
 /**
@@ -93,9 +124,22 @@ function fetchDefaultBadge(slug: string): Promise<AxiosResponse<string>> {
   return axios.get(url, { validateStatus: () => true });
 }
 
-const defaultExport = {
+/**
+ * Fetch badge from shields.io that displays an error message
+ * @param {string} message message to display
+ * @returns {AxiosResponse} response from shields.io
+ */
+function fetchErrorBadge(message: string): Promise<AxiosResponse<string>> {
+  const encodedMessage = encodeURIComponent(message);
+  // get shields url
+  const url = `https://img.shields.io/static/v1?label=custom-icon-badges&message=${encodedMessage}&color=red`;
+  // get badge from url
+  return axios.get(url, { validateStatus: () => true });
+}
+
+export {
   fetchBadgeFromRequest,
   fetchDefaultBadge,
+  fetchErrorBadge,
+  BadgeError,
 };
-
-export default defaultExport;

--- a/server/services/fetchBadges.ts
+++ b/server/services/fetchBadges.ts
@@ -69,7 +69,7 @@ function buildQueryStringFromItem(
  * @param {string|null} host hostname to validate
  * @returns {boolean} True if host is valid, otherwise false
  */
-function validHost(host: string): boolean {
+function isValidHost(host: string): boolean {
   const validHosts = [
     'img.shields.io',
     'staging.shields.io',
@@ -91,7 +91,7 @@ function getBadgeUrl(
   const params = Object.values(req.params).map((p) => encodeURIComponent(p)).join('/');
   const queryString = buildQueryStringFromItem(req, item);
   const host = typeof req.query.host === 'string' ? req.query.host : 'img.shields.io';
-  if (!validHost(host)) {
+  if (!isValidHost(host)) {
     throw new BadgeError('invalid host');
   }
   return `https://${host}/${params}?${queryString}`;

--- a/server/services/fetchBadges.ts
+++ b/server/services/fetchBadges.ts
@@ -59,7 +59,7 @@ function buildQueryStringFromItem(
   // replace logo with data url in query
   const newQuery = replacedLogoQuery(req, item.type, data);
   // remove "host" parameter from query string
-  const { host, ...rest } = newQuery;
+  delete newQuery.host;
   // build url using request params and query
   return buildQueryString(rest);
 }
@@ -138,8 +138,8 @@ function fetchErrorBadge(message: string): Promise<AxiosResponse<string>> {
 }
 
 export {
+  BadgeError,
   fetchBadgeFromRequest,
   fetchDefaultBadge,
   fetchErrorBadge,
-  BadgeError,
 };


### PR DESCRIPTION
Allows the use of different hosts in place of `img.shields.io` when fetching badges.

The allowed values for the `host` parameter are:

* [`img.shields.io`](https://img.shields.io/)
* [`staging.shields.io`](https://staging.shields.io/)
* [`formatted-dynamic-badges.herokuapp.com`](https://formatted-dynamic-badges.herokuapp.com/)