### PR TITLE
docs: Update links to demolab custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Custom Icon Badges
 
-[![stars](https://custom-icon-badges.herokuapp.com/github/stars/DenverCoder1/custom-icon-badges?logo=star)](https://github.com/DenverCoder1/custom-icon-badges/stargazers "stars")
-[![issues](https://custom-icon-badges.herokuapp.com/github/issues-raw/DenverCoder1/custom-icon-badges?logo=issue)](https://github.com/DenverCoder1/custom-icon-badges/issues "issues")
-[![license](https://custom-icon-badges.herokuapp.com/github/license/denvercoder1/custom-icon-badges?logo=law&logoColor=white)](https://github.com/DenverCoder1/custom-icon-badges/blob/main/LICENSE?rgh-link-date=2021-08-09T18%3A10%3A26Z "license MIT")
-[![discord](https://custom-icon-badges.herokuapp.com/discord/819650821314052106?color=7289DA&logo=comments&label=discord&logoColor=white)](https://discord.gg/fPrdqh3Zfu "Dev Pro Tips Discussion & Support Server")
+[![stars](https://custom-icon-badges.demolab.com/github/stars/DenverCoder1/custom-icon-badges?logo=star)](https://github.com/DenverCoder1/custom-icon-badges/stargazers "stars")
+[![issues](https://custom-icon-badges.demolab.com/github/issues-raw/DenverCoder1/custom-icon-badges?logo=issue)](https://github.com/DenverCoder1/custom-icon-badges/issues "issues")
+[![license](https://custom-icon-badges.demolab.com/github/license/denvercoder1/custom-icon-badges?logo=law&logoColor=white)](https://github.com/DenverCoder1/custom-icon-badges/blob/main/LICENSE?rgh-link-date=2021-08-09T18%3A10%3A26Z "license MIT")
+[![discord](https://custom-icon-badges.demolab.com/discord/819650821314052106?color=7289DA&logo=comments&label=discord&logoColor=white)](https://discord.gg/fPrdqh3Zfu "Dev Pro Tips Discussion & Support Server")
 
 Allows users to more easily use Octicons and their own icons and logos on [shields.io badges](https://github.com/badges/shields).
 
@@ -11,17 +11,17 @@ Allows users to more easily use Octicons and their own icons and logos on [shiel
 
 1. Get a badge URL from [shields.io](https://shields.io/).
 
-2. Replace `img.shields.io` with `custom-icon-badges.herokuapp.com`
+2. Replace `img.shields.io` with `custom-icon-badges.demolab.com`
 
 3. Use any available slug as the logo query parameter.
 
 ```md
-https://custom-icon-badges.herokuapp.com/badge/custom-badge-blue.svg?logo=paintbrush&logoColor=white
+https://custom-icon-badges.demolab.com/badge/custom-badge-blue.svg?logo=paintbrush&logoColor=white
 ```
 
 Preview:
 
-![img](https://custom-icon-badges.herokuapp.com/badge/custom-badge-blue.svg?logo=paintbrush&logoColor=white)
+![img](https://custom-icon-badges.demolab.com/badge/custom-badge-blue.svg?logo=paintbrush&logoColor=white)
 
 ## 🖼️ Existing logos
 
@@ -39,32 +39,32 @@ All [Octicons](https://primer.style/octicons/) from GitHub are supported by Cust
 
 | Slug               | Example                                                                                               |
 | ------------------ | ----------------------------------------------------------------------------------------------------- |
-| `issue-opened`     | ![img](https://custom-icon-badges.herokuapp.com/badge/Issue-red.svg?logo=issue-opened&logoColor=fff)  |
-| `repo-forked`      | ![img](https://custom-icon-badges.herokuapp.com/badge/Fork-orange.svg?logo=fork)                      |
-| `star`             | ![img](https://custom-icon-badges.herokuapp.com/badge/Star-yellow.svg?logo=star)                      |
-| `git-commit`       | ![img](https://custom-icon-badges.herokuapp.com/badge/Commit-green.svg?logo=git-commit&logoColor=fff) |
-| `repo`             | ![img](https://custom-icon-badges.herokuapp.com/badge/Repo-blue.svg?logo=repo)                        |
-| `git-pull-request` | ![img](https://custom-icon-badges.herokuapp.com/badge/Pull%20Request-purple.svg?logo=pr)              |
-| `heart`            | ![img](https://custom-icon-badges.herokuapp.com/badge/Heart-D15E9B.svg?logo=heart)                    |
-| `mail`             | ![img](https://custom-icon-badges.herokuapp.com/badge/Mail-E61B23.svg?logo=mail)                      |
+| `issue-opened`     | ![img](https://custom-icon-badges.demolab.com/badge/Issue-red.svg?logo=issue-opened&logoColor=fff)  |
+| `repo-forked`      | ![img](https://custom-icon-badges.demolab.com/badge/Fork-orange.svg?logo=fork)                      |
+| `star`             | ![img](https://custom-icon-badges.demolab.com/badge/Star-yellow.svg?logo=star)                      |
+| `git-commit`       | ![img](https://custom-icon-badges.demolab.com/badge/Commit-green.svg?logo=git-commit&logoColor=fff) |
+| `repo`             | ![img](https://custom-icon-badges.demolab.com/badge/Repo-blue.svg?logo=repo)                        |
+| `git-pull-request` | ![img](https://custom-icon-badges.demolab.com/badge/Pull%20Request-purple.svg?logo=pr)              |
+| `heart`            | ![img](https://custom-icon-badges.demolab.com/badge/Heart-D15E9B.svg?logo=heart)                    |
+| `mail`             | ![img](https://custom-icon-badges.demolab.com/badge/Mail-E61B23.svg?logo=mail)                      |
 | More Octicons      | [View all ⇨](https://primer.style/octicons)                                                           |
 
 ### Miscellaneous
 
 | Slug            | Example                                                                                                            |
 | --------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `ceylon`        | ![img](https://custom-icon-badges.herokuapp.com/badge/ceylon-E39842.svg?logo=ceylon&logoColor=fff)                 |
-| `color-swatch`  | ![img](https://custom-icon-badges.herokuapp.com/badge/color--swatch-blue.svg?logo=color-swatch&logoColor=fff)      |
-| `controller`    | ![img](https://custom-icon-badges.herokuapp.com/badge/controller-blue.svg?logo=controller)                         |
-| `issue`         | ![img](https://custom-icon-badges.herokuapp.com/badge/issue-orange.svg?logo=issue&logoColor=fff)                   |
-| `fire`          | ![img](https://custom-icon-badges.herokuapp.com/badge/fire-red.svg?logo=fire&logoColor=fff)                        |
-| `flag`          | ![img](https://custom-icon-badges.herokuapp.com/badge/flag-green.svg?logo=flag&logoColor=fff)                      |
-| `translate`     | ![img](https://custom-icon-badges.herokuapp.com/badge/translate-blue.svg?logo=translate&logoColor=white)           |
-| `trending-up`   | ![img](https://custom-icon-badges.herokuapp.com/badge/trending--up-brightgreen.svg?logoColor=fff&logo=trending-up) |
-| `trending-down` | ![img](https://custom-icon-badges.herokuapp.com/badge/trending--down-red.svg?logoColor=fff&logo=trending-down)     |
-| `phone`         | ![img](https://custom-icon-badges.herokuapp.com/badge/phone-green.svg?logo=phone&logoColor=white)                  |
-| `swi-prolog`    | ![img](https://custom-icon-badges.herokuapp.com/badge/swi--prolog-E61B23.svg?logo=swi-prolog&logoColor=fff)        |
-| Add your own    | [Upload icon ⇨](https://custom-icon-badges.herokuapp.com)                                                          |
+| `ceylon`        | ![img](https://custom-icon-badges.demolab.com/badge/ceylon-E39842.svg?logo=ceylon&logoColor=fff)                 |
+| `color-swatch`  | ![img](https://custom-icon-badges.demolab.com/badge/color--swatch-blue.svg?logo=color-swatch&logoColor=fff)      |
+| `controller`    | ![img](https://custom-icon-badges.demolab.com/badge/controller-blue.svg?logo=controller)                         |
+| `issue`         | ![img](https://custom-icon-badges.demolab.com/badge/issue-orange.svg?logo=issue&logoColor=fff)                   |
+| `fire`          | ![img](https://custom-icon-badges.demolab.com/badge/fire-red.svg?logo=fire&logoColor=fff)                        |
+| `flag`          | ![img](https://custom-icon-badges.demolab.com/badge/flag-green.svg?logo=flag&logoColor=fff)                      |
+| `translate`     | ![img](https://custom-icon-badges.demolab.com/badge/translate-blue.svg?logo=translate&logoColor=white)           |
+| `trending-up`   | ![img](https://custom-icon-badges.demolab.com/badge/trending--up-brightgreen.svg?logoColor=fff&logo=trending-up) |
+| `trending-down` | ![img](https://custom-icon-badges.demolab.com/badge/trending--down-red.svg?logoColor=fff&logo=trending-down)     |
+| `phone`         | ![img](https://custom-icon-badges.demolab.com/badge/phone-green.svg?logo=phone&logoColor=white)                  |
+| `swi-prolog`    | ![img](https://custom-icon-badges.demolab.com/badge/swi--prolog-E61B23.svg?logo=swi-prolog&logoColor=fff)        |
+| Add your own    | [Upload icon ⇨](https://custom-icon-badges.demolab.com)                                                          |
 
 ## ➕ Adding a new logo
 
@@ -74,9 +74,9 @@ The file type can be SVG, PNG, etc. but only SVG format supports the `logoColor`
 
 If you think your icon is useful to others, feel free to open a PR to add it to the README above!
 
-Demo site: <https://custom-icon-badges.herokuapp.com>
+Demo site: <https://custom-icon-badges.demolab.com>
 
-[![image](https://user-images.githubusercontent.com/20955511/128404656-30af9c39-39a4-4ac8-a4b0-2a077806a94c.png)](https://custom-icon-badges.herokuapp.com)
+[![image](https://user-images.githubusercontent.com/20955511/128404656-30af9c39-39a4-4ac8-a4b0-2a077806a94c.png)](https://custom-icon-badges.demolab.com)
 
 ## 🚀 Example Usage
 
@@ -113,32 +113,32 @@ Click to get the URL!
 [![use template][23]][23]
 [![github action][24]][24]
 
-[1]: https://custom-icon-badges.herokuapp.com/github/stars/DenverCoder1/custom-icon-badges?logo=star
-[2]: https://custom-icon-badges.herokuapp.com/github/issues-raw/DenverCoder1/custom-icon-badges?logo=issue
-[3]: https://custom-icon-badges.herokuapp.com/github/license/denvercoder1/custom-icon-badges?logo=law
-[4]: https://custom-icon-badges.herokuapp.com/github/workflow/status/DenverCoder1/custom-icon-badges/Node.js%20CI?logo=check-circle-fill&logoColor=white
-[5]: https://custom-icon-badges.herokuapp.com/github/last-commit/DenverCoder1/custom-icon-badges?logo=history&logoColor=white
-[6]: https://custom-icon-badges.herokuapp.com/github/languages/code-size/DenverCoder1/custom-icon-badges?logo=file-code&logoColor=white
-[7]: https://custom-icon-badges.herokuapp.com/github/issues-pr-closed/DenverCoder1/custom-icon-badges?color=purple&logo=git-pull-request&logoColor=white
-[8]: https://custom-icon-badges.herokuapp.com/github/v/tag/DenverCoder1/custom-icon-badges?logo=tag&logoColor=white
-[9]: https://custom-icon-badges.herokuapp.com/chrome-web-store/rating/ogffaloegjglncjfehdfplabnoondfjo?logo=thumbsup&logoColor=white
-[10]: https://custom-icon-badges.herokuapp.com/github/followers/DenverCoder1?logo=person-add&style=social&logoColor=black
-[11]: https://custom-icon-badges.herokuapp.com/github/stars/DenverCoder1/custom-icon-badges?logo=star&style=social&logoColor=black
-[12]: https://custom-icon-badges.herokuapp.com/github/forks/DenverCoder1/custom-icon-badges?logo=fork&style=social&logoColor=black
-[13]: https://custom-icon-badges.herokuapp.com/github/watchers/DenverCoder1/custom-icon-badges?logo=eye&style=social&logoColor=black
-[14]: https://custom-icon-badges.herokuapp.com/npm/dw/react-bootstrap?logo=download&style=social&label=Download&logoColor=black
-[15]: https://custom-icon-badges.herokuapp.com/badge/-My%20Repos-blue?style=for-the-badge&logoColor=white&logo=repo
-[16]: https://custom-icon-badges.herokuapp.com/badge/-Download-F25278?style=for-the-badge&logo=download&logoColor=white
-[17]: https://custom-icon-badges.herokuapp.com/badge/-123--456--7890-orange?style=for-the-badge&logo=phone&logoColor=white
-[18]: https://custom-icon-badges.herokuapp.com/badge/-hermione@spew.co.uk-red?style=for-the-badge&logo=mention&logoColor=white
-[19]: https://custom-icon-badges.herokuapp.com/badge/Colorado-USA-purple?style=for-the-badge&logo=location&logoColor=white
-[20]: https://custom-icon-badges.herokuapp.com/badge/-Open%20Issue-palegreen?style=for-the-badge&logoColor=black&logo=issue-opened
-[21]: https://custom-icon-badges.herokuapp.com/badge/-Discuss-plum?style=for-the-badge&logo=comment-discussion&logoColor=black
-[22]: https://custom-icon-badges.herokuapp.com/badge/-Install%20Package-gold?style=for-the-badge&logo=package&logoColor=black
-[23]: https://custom-icon-badges.herokuapp.com/badge/-Use%20Template-teal?style=for-the-badge&logo=repo-template&logoColor=white
-[24]: https://custom-icon-badges.herokuapp.com/badge/-Use%20GitHub%20Action-blue?style=for-the-badge&logo=workflow&logoColor=white
-[25]: https://custom-icon-badges.herokuapp.com/badge/dynamic/json?logo=fire&logoColor=fff&color=orange&label=github%20streak&query=%24.currentStreak.length&suffix=%20days&url=https%3A%2F%2Fgithub-readme-streak-stats.herokuapp.com%2F%3Fuser%3DDenverCoder1%26type%3Djson
-[26]: https://custom-icon-badges.herokuapp.com/badge/dynamic/json?logo=graph&logoColor=fff&color=blue&label=total%20contributions&query=%24.totalContributions&url=https%3A%2F%2Fgithub-readme-streak-stats.herokuapp.com%2F%3Fuser%3DDenverCoder1%26type%3Djson
+[1]: https://custom-icon-badges.demolab.com/github/stars/DenverCoder1/custom-icon-badges?logo=star
+[2]: https://custom-icon-badges.demolab.com/github/issues-raw/DenverCoder1/custom-icon-badges?logo=issue
+[3]: https://custom-icon-badges.demolab.com/github/license/denvercoder1/custom-icon-badges?logo=law
+[4]: https://custom-icon-badges.demolab.com/github/workflow/status/DenverCoder1/custom-icon-badges/Node.js%20CI?logo=check-circle-fill&logoColor=white
+[5]: https://custom-icon-badges.demolab.com/github/last-commit/DenverCoder1/custom-icon-badges?logo=history&logoColor=white
+[6]: https://custom-icon-badges.demolab.com/github/languages/code-size/DenverCoder1/custom-icon-badges?logo=file-code&logoColor=white
+[7]: https://custom-icon-badges.demolab.com/github/issues-pr-closed/DenverCoder1/custom-icon-badges?color=purple&logo=git-pull-request&logoColor=white
+[8]: https://custom-icon-badges.demolab.com/github/v/tag/DenverCoder1/custom-icon-badges?logo=tag&logoColor=white
+[9]: https://custom-icon-badges.demolab.com/chrome-web-store/rating/ogffaloegjglncjfehdfplabnoondfjo?logo=thumbsup&logoColor=white
+[10]: https://custom-icon-badges.demolab.com/github/followers/DenverCoder1?logo=person-add&style=social&logoColor=black
+[11]: https://custom-icon-badges.demolab.com/github/stars/DenverCoder1/custom-icon-badges?logo=star&style=social&logoColor=black
+[12]: https://custom-icon-badges.demolab.com/github/forks/DenverCoder1/custom-icon-badges?logo=fork&style=social&logoColor=black
+[13]: https://custom-icon-badges.demolab.com/github/watchers/DenverCoder1/custom-icon-badges?logo=eye&style=social&logoColor=black
+[14]: https://custom-icon-badges.demolab.com/npm/dw/react-bootstrap?logo=download&style=social&label=Download&logoColor=black
+[15]: https://custom-icon-badges.demolab.com/badge/-My%20Repos-blue?style=for-the-badge&logoColor=white&logo=repo
+[16]: https://custom-icon-badges.demolab.com/badge/-Download-F25278?style=for-the-badge&logo=download&logoColor=white
+[17]: https://custom-icon-badges.demolab.com/badge/-123--456--7890-orange?style=for-the-badge&logo=phone&logoColor=white
+[18]: https://custom-icon-badges.demolab.com/badge/-hermione@spew.co.uk-red?style=for-the-badge&logo=mention&logoColor=white
+[19]: https://custom-icon-badges.demolab.com/badge/Colorado-USA-purple?style=for-the-badge&logo=location&logoColor=white
+[20]: https://custom-icon-badges.demolab.com/badge/-Open%20Issue-palegreen?style=for-the-badge&logoColor=black&logo=issue-opened
+[21]: https://custom-icon-badges.demolab.com/badge/-Discuss-plum?style=for-the-badge&logo=comment-discussion&logoColor=black
+[22]: https://custom-icon-badges.demolab.com/badge/-Install%20Package-gold?style=for-the-badge&logo=package&logoColor=black
+[23]: https://custom-icon-badges.demolab.com/badge/-Use%20Template-teal?style=for-the-badge&logo=repo-template&logoColor=white
+[24]: https://custom-icon-badges.demolab.com/badge/-Use%20GitHub%20Action-blue?style=for-the-badge&logo=workflow&logoColor=white
+[25]: https://custom-icon-badges.demolab.com/badge/dynamic/json?logo=fire&logoColor=fff&color=orange&label=github%20streak&query=%24.currentStreak.length&suffix=%20days&url=https%3A%2F%2Fstreak-stats.demolab.com%2F%3Fuser%3DDenverCoder1%26type%3Djson
+[26]: https://custom-icon-badges.demolab.com/badge/dynamic/json?logo=graph&logoColor=fff&color=blue&label=total%20contributions&query=%24.totalContributions&url=https%3A%2F%2Fstreak-stats.demolab.com%2F%3Fuser%3DDenverCoder1%26type%3Djson
 
 ## 🖥️ Using a Different Badge Host
 
@@ -178,7 +178,7 @@ Deploying on your own is optional. See the steps below.
 ![image](https://user-images.githubusercontent.com/20955511/126066250-108fc119-4bc3-4ba0-9b07-0c7402c5790e.png)
 
   4. Click **"Deploy App"** at the end of the form
-  5. Once the app is deployed, you can use `<your-app-name>.herokuapp.com` in place of `custom-icon-badges.herokuapp.com`
+  5. Once the app is deployed, you can use `<your-app-name>.herokuapp.com` in place of `custom-icon-badges.demolab.com`
 	
 </details>
 
@@ -191,8 +191,8 @@ Feel free to [open an issue](http://github.com/DenverCoder1/custom-icon-badges/i
 💙 If you like this project, give it a ⭐ and share it with friends!
 
 <p align="left">
-  <a href="https://www.youtube.com/channel/UCipSxT7a3rn81vGLw9lqRkg?sub_confirmation=1"><img alt="Youtube" title="Youtube" src="https://custom-icon-badges.herokuapp.com/badge/-Subscribe-red?style=for-the-badge&logo=video&logoColor=white"/></a>
-  <a href="https://github.com/sponsors/DenverCoder1"><img alt="Sponsor with Github" title="Sponsor with Github" src="https://custom-icon-badges.herokuapp.com/badge/-Sponsor-ea4aaa?style=for-the-badge&logo=heart&logoColor=white"/></a>
+  <a href="https://www.youtube.com/channel/UCipSxT7a3rn81vGLw9lqRkg?sub_confirmation=1"><img alt="Youtube" title="Youtube" src="https://custom-icon-badges.demolab.com/badge/-Subscribe-red?style=for-the-badge&logo=video&logoColor=white"/></a>
+  <a href="https://github.com/sponsors/DenverCoder1"><img alt="Sponsor with Github" title="Sponsor with Github" src="https://custom-icon-badges.demolab.com/badge/-Sponsor-ea4aaa?style=for-the-badge&logo=heart&logoColor=white"/></a>
 </p>
 
 [☕ Buy me a coffee](https://ko-fi.com/jlawrence)

--- a/app.json
+++ b/app.json
@@ -3,8 +3,8 @@
   "description": "Allows users to more easily use their own icons and logos in shields.io badges",
   "repository": "https://github.com/DenverCoder1/custom-icon-badges",
   "keywords": ["badge", "github", "svg", "status", "custom", "badge-maker"],
-  "website": "https://custom-icon-badges.herokuapp.com",
-  "logo": "https://custom-icon-badges.herokuapp.com/favicon.png",
+  "website": "https://custom-icon-badges.demolab.com",
+  "logo": "https://custom-icon-badges.demolab.com/favicon.png",
   "env": {
     "DB_URL": {
       "description": "Mongo DB in the form 'mongodb+srv://<username>:<password>@<cluster>.mongodb.net/<dbname>?retryWrites=true&w=majority&tls=true'",

--- a/client/src/BadgePreview.tsx
+++ b/client/src/BadgePreview.tsx
@@ -9,7 +9,7 @@ class BadgePreview extends React.Component<{ url: string, label: string }> {
 	static handleError = (event: React.SyntheticEvent<HTMLImageElement>) => {
 		const target = event.target as HTMLImageElement;
 		if (!target.src.includes("critical")) {
-			target.src = "https://custom-icon-badges.herokuapp.com/badge/failed%20to%20load-try%20compressing%20the%20image%20to%20make%20it%20smaller-critical?logo=x-circle-fill";
+			target.src = "https://custom-icon-badges.demolab.com/badge/failed%20to%20load-try%20compressing%20the%20image%20to%20make%20it%20smaller-critical?logo=x-circle-fill";
 		}
 	}
 


### PR DESCRIPTION
It is still hosted on Heroku, just added a new custom domain to make it easier to move the hosting in the future if necessary