### PR TITLE
fix: Set a default for badge from request params

### DIFF
--- a/server/services/fetchBadges.ts
+++ b/server/services/fetchBadges.ts
@@ -88,7 +88,7 @@ function getBadgeUrl(
   req: Request, item: { slug: string, type: string, data: string } | null,
 ): string {
   // build url using request params and query
-  const params = Object.values(req.params).map((p) => encodeURIComponent(p)).join('/');
+  const params = Object.values(req.params).map((p) => encodeURIComponent(p)).join('/') || 'badge/-test-blue';
   const host = typeof req.query.host === 'string' ? req.query.host : 'img.shields.io';
   if (!isValidHost(host)) {
     throw new BadgeError('invalid host');


### PR DESCRIPTION
## Description

This fixes a 404 error when using axios 1.0 since the badge was requested with no params previously

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested endpoints locally

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/custom-icon-badges/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
