### PR TITLE
fix: Default host img.shields.io and remove formatted-dynamic-badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ You can set the `host` parameter to one of the following to override the hostnam
 
 -   [`img.shields.io`](https://img.shields.io)
 -   [`staging.shields.io`](https://staging.shields.io)
--   [`formatted-dynamic-badges.herokuapp.com`](https://formatted-dynamic-badges.herokuapp.com)
 
 If you would like to use a different badge host, fork and modify this repository. Create a PR if it may be useful to others.
 

--- a/server/services/fetchBadges.ts
+++ b/server/services/fetchBadges.ts
@@ -66,14 +66,13 @@ function buildQueryStringFromItem(
 
 /**
  * Validate hostname is allowed
- * @param {string|null} host hostname to validate
+ * @param {string} host hostname to validate
  * @returns {boolean} True if host is valid, otherwise false
  */
 function isValidHost(host: string): boolean {
   const validHosts = [
     'img.shields.io',
     'staging.shields.io',
-    'formatted-dynamic-badges.herokuapp.com',
   ];
   return validHosts.includes(host);
 }
@@ -89,10 +88,8 @@ function getBadgeUrl(
 ): string {
   // build url using request params and query
   const params = Object.values(req.params).map((p) => encodeURIComponent(p)).join('/');
-  const host = typeof req.query.host === 'string' ? req.query.host : 'img.shields.io';
-  if (!isValidHost(host)) {
-    throw new BadgeError('invalid host');
-  }
+  const userHost = req.query.host;
+  const host = typeof userHost === 'string' && isValidHost(userHost) ? userHost : 'img.shields.io';
   const queryString = buildQueryStringFromItem(req, item);
   return `https://${host}/${params}?${queryString}`;
 }


### PR DESCRIPTION
## Description

formatted-dynamic-badges will be shutting down since I no longer plan to keep it hosted at a cost.

See https://dynamic-badge-formatter.demolab.com/ for an alternative.

If an invalid host is passed, img.shields.io will be used instead of showing an error.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [x] Tested endpoints locally

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/custom-icon-badges/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
