### PR TITLE
fix: Prevent broken PNG when logoColor is passed

### DIFF
--- a/server/services/icons/iconDatabase.ts
+++ b/server/services/icons/iconDatabase.ts
@@ -19,7 +19,7 @@ class IconDatabaseService extends IconsService {
       return null;
     }
     // set color if it is not null
-    const data = color ? setLogoColor(icon.data, color) : icon.data;
+    const data = color && icon.type === 'svg+xml' ? setLogoColor(icon.data, color) : icon.data;
     // return icon
     return {
       slug: icon.slug,


### PR DESCRIPTION
## Summary

`logoColor` is NOT supported for PNG image icons, but this fixes a compatibility issue where images would appear broken when `logoColor` is passed.

As of now, `logoColor` still does nothing when a PNG image is loaded.

Fixes #969

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
